### PR TITLE
deleteOnExit occurs memory leaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jvnet.mimepull</groupId>
     <artifactId>mimepull</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.7-VCNC</version>
     <packaging>jar</packaging>
 
     <name>MIME streaming extension</name>
@@ -112,6 +112,29 @@
             <post>dev@mimepull.java.net</post>
         </mailingList>
     </mailingLists>
+
+    <distributionManagement>
+        <repository>
+            <id>nexus</id>
+            <name>VCNC Nexus</name>
+            <url>https://nexus.mintnote.com/repository/maven-releases/</url>
+        </repository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>VCNC Private Maven Repository</id>
+            <releases>
+                <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
+            </snapshots>
+            <url>https://nexus.mintnote.com/repository/maven-releases/</url>
+        </repository>
+    </repositories>
 
     <properties>
         <findbugs.exclude>${project.basedir}/exclude.xml</findbugs.exclude>

--- a/src/main/java/org/jvnet/mimepull/MemoryData.java
+++ b/src/main/java/org/jvnet/mimepull/MemoryData.java
@@ -95,7 +95,8 @@ final class MemoryData implements Data {
                 String suffix = config.getTempFileSuffix();
                 File tempFile = TempFiles.createTempFile(prefix, suffix, config.getTempDir());
                 // delete the temp file when VM exits as a last resort for file clean up
-                tempFile.deleteOnExit();
+                // deleteOnExit occurs memory leaks
+                // tempFile.deleteOnExit();
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.log(Level.FINE, "Created temp file = {0}", tempFile);
                 }


### PR DESCRIPTION
deleteOnExit이 없더라도 MIMEPart들을 잘 close해주면 file이 안전하게 삭제됩니다.